### PR TITLE
DRA-2021: update postgres version from `42.2.8.jre7` -> `42.7.8`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,9 +288,8 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.8.jre7</version>
+                <version>42.7.8</version>
             </dependency>
-
 
             <!--For the standard unit test-->
             <dependency>


### PR DESCRIPTION
Fixes this postgres exception:
```
org.postgresql.util.PSQLException: Can't infer the SQL type to use for an instance of java.time.OffsetDateTime. Use setObject() with an explicit Types value to specify the type to use.
        at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:955)
```

Java package `java.time` where OffsetDateTime is defined, came in Java 8: https://docs.oracle.com/javase/8/docs/technotes/guides/datetime/index.html