### PR TITLE
Add plugin for test report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,41 @@
         <module>bff</module>
     </modules>
 
+    <!-- Important: reporting must come after <modules> -->
+    <reporting>
+        <plugins>
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-report-plugin</artifactId>
+            <version>3.5.5</version>
+            <configuration>
+                <!-- This links the report to the parent level -->
+                <aggregate>true</aggregate>
+            </configuration>
+        </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>2.4</version> <!-- Downgrading for stability with Maven 4 -->
+                <configuration>
+                    <tags>
+                        <tag>TODO</tag>
+                        <tag>FIXME</tag>
+                        <tag>@deprecated</tag>
+                    </tags>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <!-- For linking between parent and child module reports -->
+    <distributionManagement>
+      <site>
+        <id>local-site</id>
+	<url>file://${project.basedir}/target/staging</url>
+      </site>
+    </distributionManagement>
+
     <repositories>
         <repository>
             <id>sbforge-nexus</id>


### PR DESCRIPTION
Running 'mvn site site:stage' will generate a test report for all child modules. The report is saved at /target/staging/*html.

Will only work when all child modules are found in project root dir.